### PR TITLE
Support image_end_url in generation api

### DIFF
--- a/api.go
+++ b/api.go
@@ -5,12 +5,13 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/gin-gonic/gin"
 	"io"
 	"luma-api/common"
 	"net/http"
 	"regexp"
 	"strings"
+
+	"github.com/gin-gonic/gin"
 )
 
 const (

--- a/api.go
+++ b/api.go
@@ -20,6 +20,10 @@ const (
 	FileUploadEndpoint = "/api/photon/v1/generations/file_upload"
 )
 
+const (
+	OfficalImageRoot = "https://storage.cdn-luma.com/app_data/photon"
+)
+
 var CommonHeaders = map[string]string{
 	"Content-Type": "application/json",
 	"User-Agent":   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36",
@@ -43,7 +47,7 @@ func Generations(c *gin.Context) {
 		common.WrapperLumaError(c, err, http.StatusInternalServerError)
 		return
 	}
-	if genRequest.ImageUrl != "" && !strings.HasPrefix(genRequest.ImageUrl, "https://storage.cdn-luma.com/app_data/photon") {
+	if genRequest.ImageUrl != "" && !strings.HasPrefix(genRequest.ImageUrl, OfficalImageRoot) {
 		uploadRes, err := uploadFile(genRequest.ImageUrl)
 		if err != nil {
 			common.WrapperLumaError(c, err, http.StatusInternalServerError)
@@ -51,6 +55,15 @@ func Generations(c *gin.Context) {
 		}
 		common.Logger.Infow("upload file success", "uploadRes", uploadRes)
 		genRequest.ImageUrl = uploadRes.PublicUrl
+	}
+	if genRequest.ImageEndUrl != "" && !strings.HasPrefix(genRequest.ImageEndUrl, OfficalImageRoot) {
+		uploadRes, err := uploadFile(genRequest.ImageEndUrl)
+		if err != nil {
+			common.WrapperLumaError(c, err, http.StatusInternalServerError)
+			return
+		}
+		common.Logger.Infow("upload file success", "uploadRes", uploadRes)
+		genRequest.ImageEndUrl = uploadRes.PublicUrl
 	}
 
 	reqData, _ := json.Marshal(genRequest)

--- a/api.go
+++ b/api.go
@@ -66,16 +66,6 @@ func Generations(c *gin.Context) {
 		genRequest.ImageEndUrl = uploadRes.PublicUrl
 	}
 
-	if genRequest.ImageEndUrl != "" && !strings.HasPrefix(genRequest.ImageEndUrl, "https://storage.cdn-luma.com/app_data/photon") {
-		uploadRes2, err := uploadFile(genRequest.ImageEndUrl)
-		if err != nil {
-			common.WrapperLumaError(c, err, http.StatusInternalServerError)
-			return
-		}
-		common.Logger.Infow("upload file success", "uploadRes2", uploadRes2)
-		genRequest.ImageEndUrl = uploadRes2.PublicUrl
-	}
-
 	reqData, _ := json.Marshal(genRequest)
 
 	resp, err := DoRequest("POST", fmt.Sprintf(common.BaseUrl+SubmitEndpoint), bytes.NewReader(reqData), nil)

--- a/chat.go
+++ b/chat.go
@@ -4,13 +4,14 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/gin-gonic/gin"
-	"github.com/sashabaranov/go-openai"
 	"io"
 	"luma-api/common"
 	"luma-api/middleware"
 	"net/http"
 	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sashabaranov/go-openai"
 )
 
 const (

--- a/main.go
+++ b/main.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"fmt"
-	"github.com/gin-gonic/gin"
 	"log"
 	"luma-api/common"
 	"luma-api/middleware"
 	"net/http"
 	"runtime/debug"
+
+	"github.com/gin-gonic/gin"
 )
 
 func main() {

--- a/models.go
+++ b/models.go
@@ -5,6 +5,7 @@ type GenRequest struct {
 	AspectRatio  string `json:"aspect_ratio"`        // require
 	ExpandPrompt bool   `json:"expand_prompt"`       // require
 	ImageUrl     string `json:"image_url,omitempty"` //option, uploaded refer image url
+	ImageEndUrl  string `json:"image_end_url,omitempty"`
 }
 
 type VideoTask struct {

--- a/models.go
+++ b/models.go
@@ -1,10 +1,11 @@
 package main
 
 type GenRequest struct {
-	UserPrompt   string `json:"user_prompt"`         // require
-	AspectRatio  string `json:"aspect_ratio"`        // require
-	ExpandPrompt bool   `json:"expand_prompt"`       // require
-	ImageUrl     string `json:"image_url,omitempty"` //option, uploaded refer image url
+	UserPrompt   string `json:"user_prompt"`             // require
+	AspectRatio  string `json:"aspect_ratio"`            // require
+	ExpandPrompt bool   `json:"expand_prompt"`           // require
+	ImageUrl     string `json:"image_url,omitempty"`     //option, uploaded refer image url
+	ImageEndUrl  string `json:"image_end_url,omitempty"` //option, uploaded refer image url
 }
 
 type VideoTask struct {

--- a/request.go
+++ b/request.go
@@ -1,12 +1,13 @@
 package main
 
 import (
-	tls_client "github.com/bogdanfinn/tls-client"
-	"github.com/bogdanfinn/tls-client/profiles"
 	"io"
 	"luma-api/common"
 	"net/http"
 	"net/url"
+
+	tls_client "github.com/bogdanfinn/tls-client"
+	"github.com/bogdanfinn/tls-client/profiles"
 )
 
 var TlsHTTPClient tls_client.HttpClient

--- a/router.go
+++ b/router.go
@@ -21,6 +21,7 @@ func RegisterRouter(r *gin.Engine) {
 	{
 		apiRouter.POST("/generations/", Generations)
 		apiRouter.GET("/generations/*action", Fetch)
+		apiRouter.GET("/download_video_url/*action", Download)
 		apiRouter.POST("/generations/file_upload", Upload)
 	}
 }

--- a/router.go
+++ b/router.go
@@ -1,11 +1,12 @@
 package main
 
 import (
+	"luma-api/docs"
+	"luma-api/middleware"
+
 	"github.com/gin-gonic/gin"
 	swaggerfiles "github.com/swaggo/files"
 	ginSwagger "github.com/swaggo/gin-swagger"
-	"luma-api/docs"
-	"luma-api/middleware"
 )
 
 func RegisterRouter(r *gin.Engine) {


### PR DESCRIPTION
Follow the new web API changes on the Luma website. Support `image_end_url` to customize the first and last frames of the video.
