### PR TITLE
fixed a bug related to submitting the end-frame.

### DIFF
--- a/luma.go
+++ b/luma.go
@@ -5,14 +5,15 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/gin-gonic/gin"
-	"github.com/pkg/errors"
 	"io"
 	"luma-api/common"
 	"net/http"
 	"regexp"
 	"strings"
 	"sync"
+
+	"github.com/gin-gonic/gin"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -112,7 +113,7 @@ func doGeneration(c *gin.Context) {
 		genRequest.ImageUrl = uploadRes.PublicUrl
 	}
 
-	if genRequest.ImageEndUrl != "" && !strings.HasPrefix(genRequest.ImageUrl, "https://storage.cdn-luma.com/app_data/photon") {
+	if genRequest.ImageEndUrl != "" && !strings.HasPrefix(genRequest.ImageEndUrl, "https://storage.cdn-luma.com/app_data/photon") {
 		uploadRes, relayErr := uploadFile(genRequest.ImageEndUrl)
 		if relayErr != nil {
 			ReturnLumaError(c, relayErr.ErrorResp, relayErr.StatusCode)


### PR DESCRIPTION
Fixed a bug related to submitting the end-frame.

In the latest version, submitting the end of the session will cause an error.

```JSON
{
    "gen_api_response": {
        "created_at": "2024-07-29T21:25:14.144179Z",
        "estimate_wait_seconds": null,
        "id": "XXXXXXXX-ff9c-408e-9515-XXXXXXXXXXXX",
        "last_frame": null,
        "liked": null,
        "prompt": "",
        "state": "pending",
        "thumbnail": null,
        "video": null
    },
    "gen_api_status": 201,
    "status": "FAILED"
}
```

This patch can resolve the issue.